### PR TITLE
docs: fix --listTests doc regarding JSON

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -202,7 +202,7 @@ Run all tests affected by file changes in the last commit made. Behaves similarl
 
 ### `--listTests`
 
-Lists all tests as JSON that Jest will run given the arguments, and exits. This can be used together with `--findRelatedTests` to know which tests Jest will run.
+Lists all tests that Jest will run given the arguments, and exits. Can be used together with `--findRelatedTests` to know which tests Jest will run. Can be used together with `--json`.
 
 ### `--logHeapUsage`
 


### PR DESCRIPTION
<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

- [x] Update the docs for `--listTests` to better indicate the default is text and JSON is controlled through `--json` option
- [ ] Copy into the appropriate version docs
- [ ] Update CHANGELOG.md


originally documented: https://github.com/facebook/jest/pull/7046
behavior changed: https://github.com/facebook/jest/pull/4229

## Test plan

reviewers read the text =)